### PR TITLE
update CI to run only on updates to pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: ci
 run-name: Testing and integration
-on: [push]
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
 jobs:
   lint-test-python-backend:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Right now we are running all of Github actions for every push. I'm only checking the CI when we get to the pull request stage, so I think we should change the trigger to save compute resources